### PR TITLE
Barre recherche responsive

### DIFF
--- a/lescitronsdetoto-frontend/src/components/HelloWorld.vue
+++ b/lescitronsdetoto-frontend/src/components/HelloWorld.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="fill-height" color="transparent">
+  <v-container color="transparent">
     <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/lemon.svg" />
 

--- a/lescitronsdetoto-frontend/src/components/SearchBar.vue
+++ b/lescitronsdetoto-frontend/src/components/SearchBar.vue
@@ -1,0 +1,79 @@
+<template>
+    <v-sheet color="amber" width="parent" class="pa-6">
+        <v-row>
+            <v-select style="width: 2em" label="Marque" v-model="this.store.selected.make"
+                :items="this.store.makes"></v-select>
+            <v-select style="width: 2em" label="Modéle" v-model="this.store.selected.model"
+                :items="this.store.models"></v-select>
+            <v-select style="width: 2em" label="Année" v-model="this.store.selected.year"
+                :items="this.store.years"></v-select>
+        </v-row><v-row>
+            <v-range-slider v-model="this.store.selected.priceRange" :step="this.store.priceIncrement"
+                :min="this.store.minPrice" :max="this.store.maxPrice">
+                <template v-slot:prepend>
+                    <v-text-field v-model="this.store.selected.priceRange[0]" hide-details single-line type="number"
+                        variant="outlined" density="compact" style="width: 7em" :min="this.store.minPrice"
+                        :max="this.store.maxPrice" :step="this.store.priceIncrement"></v-text-field>
+                </template>
+                <template v-slot:append>
+                    <v-text-field v-model="this.store.selected.priceRange[1]" hide-details single-line type="number"
+                        variant="outlined" style="width: 7em" density="compact" :min="this.store.minPrice"
+                        :max="this.store.maxPrice" :step="this.store.priceIncrement"></v-text-field>
+                </template>
+            </v-range-slider>
+
+            <v-btn prepend-icon="mdi-car-search" class="mx-2" aria-label="confirmer"
+                color="green-lighten-2" @click="this.searchVehicles()">Confirmer</v-btn>
+            <v-btn prepend-icon="mdi-cancel" class="mx-2" aria-label="annuler" color="red-lighten-2"
+                @click="this.cancel()">Annuler</v-btn>
+
+        </v-row>
+    </v-sheet>
+</template>
+
+<script>
+import { useVehiclesStore } from '@/store/vehicles';
+
+export default {
+    data: function () {
+        return {
+            store: useVehiclesStore(),
+        };
+    },
+    methods: {
+        searchVehicles() {
+            this.store.getVehiclesList();
+        },
+        cancel() {
+            this.store.reset();
+        }
+    },
+    computed: {
+        watchMake() {
+            return this.store.selected.make
+        },
+        watchYear() {
+            return this.store.selected.year
+        },
+    },
+    watch: {
+        async watchMake(newMake, oldMake) {
+            await this.store.loadModels();
+            this.store.selected.model = null;
+        },
+        async watchYear(newYear, oldYear) {
+            await this.store.loadModels();
+            if (!this.store.models.includes(this.store.selected.model)) {
+                this.store.selected.model = null;
+            }
+        }
+
+    },
+    created() {
+        this.store.loadMakes();
+        this.store.loadYears();
+        this.store.loadModels()
+    }
+
+}
+</script>

--- a/lescitronsdetoto-frontend/src/components/SearchBar/desktop.vue
+++ b/lescitronsdetoto-frontend/src/components/SearchBar/desktop.vue
@@ -1,12 +1,12 @@
 <template>
-    <v-sheet color="amber" width="parent" class="pa-6">
+    <v-sheet color="amber" width="parent" class="pt-6 px-6">
         <v-row>
             <v-select style="width: 2em" label="Marque" v-model="this.store.selected.make"
-                :items="this.store.makes"></v-select>
+                :items="this.store.makes" density="compact"></v-select>
             <v-select style="width: 2em" label="Modéle" v-model="this.store.selected.model"
-                :items="this.store.models"></v-select>
+                :items="this.store.models" density="compact"></v-select>
             <v-select style="width: 2em" label="Année" v-model="this.store.selected.year"
-                :items="this.store.years"></v-select>
+                :items="this.store.years" density="compact"></v-select>
         </v-row><v-row>
             <v-range-slider v-model="this.store.selected.priceRange" :step="this.store.priceIncrement"
                 :min="this.store.minPrice" :max="this.store.maxPrice">

--- a/lescitronsdetoto-frontend/src/components/SearchBar/mobile.vue
+++ b/lescitronsdetoto-frontend/src/components/SearchBar/mobile.vue
@@ -1,0 +1,115 @@
+<template>
+    <v-dialog v-model="dialog" fullscreen :scrim="false" transition="dialog-bottom-transition">
+        <template v-slot:activator="{ props }">
+            <v-btn block color="amber" dark v-bind="props">
+                Rechercher
+            </v-btn>
+        </template>
+        <v-card>
+            <v-toolbar dark color="amber">
+                <v-btn icon dark @click="dialog = false" aria-label="annuler">
+                    <v-icon>mdi-close</v-icon>
+                </v-btn>
+                <v-toolbar-title>Rechercher</v-toolbar-title>
+                <v-spacer></v-spacer>
+                <v-toolbar-items>
+                    <v-btn prepend-icon="mdi-car-search" variant="text" @click="this.searchVehicles()"
+                        aria-label="confirmer">
+                        Confirmer
+                    </v-btn>
+                </v-toolbar-items>
+            </v-toolbar>
+            <v-list>
+                <v-list-item>
+                    <v-select label="Marque" v-model="this.store.selected.make" :items="this.store.makes"
+                        density="compact"></v-select>
+                </v-list-item>
+
+                <v-list-item>
+
+                    <v-select label="Année" v-model="this.store.selected.year" :items="this.store.years"
+                        density="compact"></v-select>
+                </v-list-item>
+
+                <v-list-item>
+                    <v-select label="Modéle" v-model="this.store.selected.model" :items="this.store.models"
+                        density="compact"></v-select>
+                </v-list-item>
+                <v-list-subheader>Prix entre </v-list-subheader>
+                <v-list-item>
+                    <v-range-slider class="mt-8 mx-6" v-model="this.store.selected.priceRange"
+                        :step="this.store.priceIncrement" :min="this.store.minPrice" :max="this.store.maxPrice"
+                        thumb-label="always">
+                    </v-range-slider>
+                </v-list-item>
+
+                <v-btn block prepend-icon="mdi-cancel" aria-label="annuler" color="red-lighten-2"
+                    @click="this.cancel()">Annuler</v-btn>
+            </v-list>
+        </v-card>
+    </v-dialog>
+    <v-sheet class="pa-1 text-center">{{ searchToString }} <br> {{ priceToString }}</v-sheet>
+</template>
+
+<script>
+import { useVehiclesStore } from '@/store/vehicles';
+
+export default {
+    data: function () {
+        return {
+            store: useVehiclesStore(),
+            dialog: false
+        };
+    },
+    methods: {
+        searchVehicles() {
+            this.dialog = false;
+            this.store.getVehiclesList();
+        },
+        cancel() {
+            this.store.reset();
+        }
+    },
+    computed: {
+        watchMake() {
+            return this.store.selected.make
+        },
+        watchYear() {
+            return this.store.selected.year
+        },
+        searchToString() {
+
+        
+            const concatMake = (this.store.selected.make !== null)? this.store.selected.make : "Voitures";
+            const concatModel = (this.store.selected.model !== null)? this.store.selected.model + " " : "";
+
+            const concatYear = (this.store.selected.year !== null)? this.store.selected.year : "";
+            const concatSpace = (concatMake === "")? "" : (concatModel !== "" || concatYear !== "")? " | " : "";
+            return concatMake + concatSpace + concatModel + concatYear;
+        },
+        priceToString() {
+
+            return "Entre : " + this.store.selected.priceRange[0] + " & " + this.store.selected.priceRange[1];
+        }
+    },
+    watch: {
+        async watchMake(newMake, oldMake) {
+            await this.store.loadModels();
+            this.store.selected.model = null;
+        },
+        async watchYear(newYear, oldYear) {
+            await this.store.loadModels();
+            if (!this.store.models.includes(this.store.selected.model)) {
+                this.store.selected.model = null;
+            }
+        }
+
+    },
+    created() {
+        this.store.loadMakes();
+        this.store.loadYears();
+        this.store.loadModels()
+    }
+
+}
+</script>

--- a/lescitronsdetoto-frontend/src/layouts/default/SearchBar.vue
+++ b/lescitronsdetoto-frontend/src/layouts/default/SearchBar.vue
@@ -1,0 +1,26 @@
+<template>
+    <v-container width="100%" color="amber">
+        <mobileSearchBar v-if="!isSM"></mobileSearchBar>
+        <desktopSearchBar v-else></desktopSearchBar>
+    </v-container>
+</template>
+
+<script>
+import desktopSearchBar from '@/components/SearchBar/desktop.vue';
+import mobileSearchBar from '@/components/SearchBar/mobile.vue'
+
+export default {
+    components: {
+        desktopSearchBar,mobileSearchBar
+    },
+    data: function () {
+        return {};
+    },
+    computed: {
+        isSM() {
+            return this.$vuetify.display.smAndUp;
+        },
+
+    },
+    }
+</script>

--- a/lescitronsdetoto-frontend/src/services/MakesAPI.js
+++ b/lescitronsdetoto-frontend/src/services/MakesAPI.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import {prune} from './common';
+
+const apiURL = 'https://vpic.nhtsa.dot.gov/api/vehicles/GetMakesForVehicleType/car?format=json';
+
+export async function fetchMakes() {
+    
+    const options = {
+        method: 'GET',
+        url: apiURL,
+    };
+
+    const response = await axios.request(options);
+    if (response.status === 200) {
+        const prunedMakes = await prune(response.data.Results,"MakeName");
+        
+        //console.log(JSON.stringify(prunedMakes,null,"  "));
+        return prunedMakes;
+    } else {
+        throw new Error('Failed to fetch Makes data');
+    }
+}

--- a/lescitronsdetoto-frontend/src/services/ModelsAPI.js
+++ b/lescitronsdetoto-frontend/src/services/ModelsAPI.js
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import {prune} from './common';
+
+const makeYearURL = 'https://vpic.nhtsa.dot.gov/api/vehicles/getmodelsformakeyear/make/';
+const makeURL = 'https://vpic.nhtsa.dot.gov/api/vehicles/getmodelsformake/';
+
+export async function fetchModels(make,year) {
+
+    let apiURL;
+
+    if (year) {
+        apiURL = makeYearURL + make + '/modelyear/' + year + '?format=json';
+    } else {
+        apiURL = makeURL + make + '?format=json';
+    }
+
+    const options = {
+        method: 'GET',
+        url: apiURL
+    };
+
+    const response = await axios.request(options);
+    if (response.status === 200) {
+        const prunedModels = await prune(response.data.Results,"Model_Name");
+        
+        //console.log(JSON.stringify(prunedModels,null,"  "));
+        return prunedModels;
+    } else {
+        throw new Error('Failed to fetch Models data');
+    }
+    }

--- a/lescitronsdetoto-frontend/src/services/VINAPI.js
+++ b/lescitronsdetoto-frontend/src/services/VINAPI.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const apiURL = 'https://vpic.nhtsa.dot.gov/api/vehicles/decodevinvaluesextended/';
 
-export async function fetchVehicle(vin) {
+export async function fetchVIN(vin) {
 
     const options = {
         method: 'GET',

--- a/lescitronsdetoto-frontend/src/services/VINAPI.js
+++ b/lescitronsdetoto-frontend/src/services/VINAPI.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const apiURL = 'https://vpic.nhtsa.dot.gov/api/vehicles/decodevinvaluesextended/';
+
+export async function fetchVehicle(vin) {
+
+    const options = {
+        method: 'GET',
+        url: apiURL + vin + '?format=json',
+    };
+
+    const response = await axios.request(options);
+    if (response.data.Results[0].ErrorCode === "0") {
+        return response.data.Results[0];
+    } else {
+        throw response.data.Results[0].ErrorText;
+    }
+}

--- a/lescitronsdetoto-frontend/src/services/common.js
+++ b/lescitronsdetoto-frontend/src/services/common.js
@@ -1,0 +1,11 @@
+export async function prune(objects, value) {
+    let pruneValuesSet = new Set();
+
+    objects.forEach(object => {
+        pruneValuesSet.add(object[value]);
+    });
+
+    let pruneValues = Array.from(pruneValuesSet);
+
+    return pruneValues;
+}

--- a/lescitronsdetoto-frontend/src/services/common.js
+++ b/lescitronsdetoto-frontend/src/services/common.js
@@ -9,3 +9,22 @@ export async function prune(objects, value) {
 
     return pruneValues;
 }
+
+export async function generateYears() {
+
+    // nombre d'année à retourner dans le passé 
+    const pastYears = 26
+
+    const d = new Date();
+
+    // determine l'année courante ajoute + 1 pour exemple les modeles 2024 qui sort durant l'année 2023
+    const startingYear = d.getFullYear() + 1;
+    let years = [];
+    let year;
+    for (let i = 0; i <= pastYears; i++ ) {
+        year = startingYear - i;
+        years.push(year);
+    }
+
+    return years;
+}

--- a/lescitronsdetoto-frontend/src/store/vehicles.js
+++ b/lescitronsdetoto-frontend/src/store/vehicles.js
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 import { fetchMakes } from '../services/MakesAPI'
 import { fetchModels } from '../services/ModelsAPI'
 import { fetchVIN } from '../services/VINAPI'
-import { generateYear } from '../services/common'
+import { generateYears } from '../services/common'
 
 export const useVehiclesStore = defineStore('vehicles', {
   state: () => ({

--- a/lescitronsdetoto-frontend/src/store/vehicles.js
+++ b/lescitronsdetoto-frontend/src/store/vehicles.js
@@ -1,0 +1,57 @@
+// Utilities
+import { defineStore } from 'pinia';
+import { fetchMakes } from '../services/MakesAPI'
+import { fetchModels } from '../services/ModelsAPI'
+import { fetchVIN } from '../services/VINAPI'
+import { generateYear } from '../services/common'
+
+export const useVehiclesStore = defineStore('vehicles', {
+  state: () => ({
+    makes: [],
+    years: [],
+    models: [],
+
+    minPrice: 0,
+    maxPrice: 500000,
+    priceIncrement: 1000,
+
+    selected: {
+      make: null,
+      year: null,
+      model: null,
+      priceRange: [0,500000]
+    },
+    vehicles: [],
+
+    vehicle: {
+      vin: null,
+      local: null,
+      api: null
+    }
+
+  }),
+  actions: {
+    async loadMakes() {
+      this.makes = await fetchMakes();
+    },
+    async loadYears() {
+      this.years = await generateYears();
+    },
+    async loadModels() {
+      this.models = await fetchModels(this.selected.make,this.selected.year);
+    },
+    async loadVIN(vin) {
+      this.vehicle.api = await fetchVIN(vin);
+    },
+    async getVehiclesList() {
+      
+    },
+    async reset() {
+      this.selected.make = null;
+      this.selected.year = null;
+      this.selected.model = null;
+      this.selected.priceRange[0] = this.minPrice;
+      this.selected.priceRange[1] = this.maxPrice;
+    }
+  }
+});

--- a/lescitronsdetoto-frontend/src/views/Home.vue
+++ b/lescitronsdetoto-frontend/src/views/Home.vue
@@ -1,7 +1,9 @@
 <template>
+  <SearchBar />
   <HelloWorld />
 </template>
 
 <script setup>
   import HelloWorld from '@/components/HelloWorld.vue'
+  import SearchBar from '@/components/SearchBar.vue'
 </script>

--- a/lescitronsdetoto-frontend/src/views/Home.vue
+++ b/lescitronsdetoto-frontend/src/views/Home.vue
@@ -5,5 +5,5 @@
 
 <script setup>
   import HelloWorld from '@/components/HelloWorld.vue'
-  import SearchBar from '@/components/SearchBar.vue'
+  import SearchBar from '@/layouts/default/SearchBar.vue'
 </script>


### PR DESCRIPTION
lescitronsdetoto-frontend/src/components/HelloWorld.vue
- retrait de class="fill-height" causait un espace blanc au bas de la page.

lescitronsdetoto-frontend/src/components/SearchBar.vue
> déplacmemt vers layouts/default pour etre le defaut et gérer le responsive qui est des composant séparé

lescitronsdetoto-frontend/src/components/SearchBar/desktop.vue
+ code original de la barre de recherche pour grand écran, mais ne prend plus largeur total de l'écran

lescitronsdetoto-frontend/src/components/SearchBar/mobile.vue
+ code pour version mobile de la barre de recherche

lescitronsdetoto-frontend/src/layouts/default/SearchBar.vue
+ code pour déterminer si utilise la version desktop ou mobile

lescitronsdetoto-frontend/src/views/Home.vue
> changement pour utiliser le SearchBar dans layouts/default