### PR TITLE
MB 230912 1652: Ajustment visuelle page détaille dialoguq

### DIFF
--- a/lescitronsdetoto-frontend/src/components/VehicleListItem.vue
+++ b/lescitronsdetoto-frontend/src/components/VehicleListItem.vue
@@ -1,28 +1,32 @@
 <template>
   <v-card :color="colourPrimary" class="pa-2">
     <v-card-title class="headColour">{{ vehicleName }}</v-card-title>
-    <v-img color="grey-lighten-3" :width="200" :height="100" aspect-ratio="16/9" cover :src="carImg">
-    </v-img>
-    <div class="card-content">
-      <div v-if="this.promo" class="my-2">
+    <v-row class="mt-1">
+      <v-img color="grey-lighten-3" :width="200" :height="163" aspect-ratio="16/9" cover :src="carImg">
+        <div class="overlay-text mx-4">
+      <div v-if="this.promo">
         <p class="text-right font-weight-bold promo"><v-icon color="red">mdi-seal</v-icon>{{ formatedPromo }}</p>
-        <p class="text-right text-decoration-line-through">{{ formatedPrice }}</p>
+        <p class="text-right text-decoration-line-through reg">{{ formatedPrice }}</p>
       </div>
-      <div v-else class="my-2">
+      <div v-else>
         <p class=" text-right font-weight-bold">{{ formatedPrice }}</p>
       </div>
+      </div></v-img>
+    
+      <v-col cols="12"></v-col>
+    </v-row>
+
       <v-dialog v-model="dialog" fullscreen
       :scrim="true"
       transition="dialog-bottom-transition">
         <template v-slot:activator="{ props }">
-          <v-btn color="primary" v-bind="props">
+          <v-btn block color="primary" v-bind="props">
             Voir plus
           </v-btn>
         </template>
-        <detailled-vehicle :id="this.id" @close-dialog="this.dialog = !this.dialog"></detailled-vehicle>
+        <detailled-vehicle class="mb-8" :id="this.id" :isDialog="true" @close-dialog="this.dialog = !this.dialog"></detailled-vehicle>
       </v-dialog>
       
-    </div>
   </v-card>
 </template>
 
@@ -82,10 +86,27 @@ export default {
 }
 
 .promo {
-  color: navy;
+  color: white;
 }
 
+.reg {
+  color: #ECEFF1;
+}
 .headColour {
   background-color: gold;
 }
+
+.overlay-text {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding: 10px;
+  background-color: rgba(0, 0, 0, 0.2);
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: bold;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.7);
+  border-top-left-radius: 25px;
+}
+
 </style>

--- a/lescitronsdetoto-frontend/src/views/DetailledVehicle.vue
+++ b/lescitronsdetoto-frontend/src/views/DetailledVehicle.vue
@@ -1,14 +1,16 @@
 <template>
-    <v-toolbar dark color="lime">
-        <v-toolbar-title>Les citrons de Toto</v-toolbar-title>
+    <v-sheet color="light-blue">
+    <v-toolbar v-if="isDialog" dark color="lime">
+        <v-toolbar-title @click="$emit('closeDialog')">Les citrons de Toto</v-toolbar-title>
         <v-spacer></v-spacer>
+        <v-btn variant="text" aria-label="partager" icon="mdi-share-variant"></v-btn>
         <v-toolbar-items > <v-btn bg-color="error" icon dark @click="$emit('closeDialog')">
             <v-icon>mdi-close</v-icon>
         </v-btn></v-toolbar-items>
     </v-toolbar>
 
-    <v-sheet color="blue-lighten-1">
-        <div class="ma-4 mb-16">
+    <v-container color="blue-lighten-1">
+        <div class="ma-4">
         <v-row v-if="!this.load" class="flex d-flex">
             <v-col cols="12" sm="4">
                 <v-carousel height="250" width="350" hide-delimiter-background show-arrows="hover">
@@ -53,7 +55,7 @@
 
         <v-row v-if="!this.load">
             <v-col cols="12" sm="4">
-                <v-table>
+                <v-table  class="mb-8">
                     <thead>
                         <tr>
                             <th class="text-left">
@@ -82,7 +84,7 @@
                             <td>{{ this.api.EngineCylinders }}</td>
                         </tr>
                         <tr v-if="this.local.km !== null">
-                            <td>KM/H</td>
+                            <td>KM</td>
                             <td>{{ this.local.km }}</td>
                         </tr>
                         <tr v-if="this.api.TractionControl !== ''">
@@ -115,12 +117,14 @@
 
             <v-col cols="12" sm="8">
 
-                <v-card class="pa-8 mb-16" :color="this.colourPrimary">{{ this.local.longDescription }}</v-card>
+                <v-card class="pa-8 mb-8" :color="this.colourPrimary">{{ this.local.longDescription }}</v-card>
 
             </v-col>
         </v-row>
     </div>
-    </v-sheet>
+    </v-container>
+    <v-btn v-if="!this.loading && isDialog" size="x-large" aria-label="fermer dialogue véhicule" color="red-lighten-3" block @click="$emit('closeDialog')"><v-icon size="x-large" icon="mdi-menu-down" ></v-icon></v-btn>
+</v-sheet>
 </template>
   
 <script>
@@ -128,12 +132,17 @@ import { useVehiclesStore } from '@/store/vehicles';
 import { useAppStore } from '@/store/app';
 import { priceFormatting } from '@/services/common';
 import session from '@/session';
+import FooterBar from '@/layouts/default/FooterBar.vue';
 
 const appStore = useAppStore();
 const store = useVehiclesStore();
 export default {
+    components: {
+FooterBar: FooterBar
+    },
     props: {
         id: String,
+        isDialog: Boolean
     },
     data: function () {
         return {
@@ -156,6 +165,9 @@ export default {
         },
         appointmentURL() {
             return "/newappointment/" + this.id;
+        },
+        shareURL() {
+            return "/vehicles/" + this.id;
         },
         colourPrimary() {
             return appStore.colourPrimary;


### PR DESCRIPTION
#Frontend

## @/src/components/VehicleListItem.vue
- ajustement visuel du prix et de l'image.

##  @/src/views/DetailledVehicle.vue
- changement de KM/H pour KM
- ajout condition pour que le app bar ne s'affiche que lorsqu'un dialog
- ajout bouton partage pour obtenir l'url du véhicules
- ajout bouton fermer en bas de la page lorsqu'un dialoque. s'affiche que si un dialoque
- ajustement dimension de la page via v-sheet et v-container
- début de géneration du computed shareURL pour obtenir le chemin pour le liens du véhicules.